### PR TITLE
Add hash bang to stop error

### DIFF
--- a/bin/worker.js
+++ b/bin/worker.js
@@ -1,3 +1,5 @@
+#! /usr/bin/env node
+
 var BeanstalkWorkerCluster = require('../lib/beanstalk_worker_cluster').BeanstalkWorkerCluster;
 
 process.on('SIGINT', function() {


### PR DESCRIPTION
Stops

```
/usr/local/bin/nbworker: line 1: syntax error near unexpected token `('
/usr/local/bin/nbworker: line 1: `var BeanstalkWorkerCluster = require('../lib/beanstalk_worker_cluster').BeanstalkWorkerCluster;'
```
